### PR TITLE
Fix -- Fix deprecation warning with AllowDynamicProperties attribute

### DIFF
--- a/lib/Cake/Core/CakeObject.php
+++ b/lib/Cake/Core/CakeObject.php
@@ -27,6 +27,7 @@ App::uses('Set', 'Utility');
  *
  * @package       Cake.Core
  */
+#[\AllowDynamicProperties]
 class CakeObject {
 
 /**


### PR DESCRIPTION
> Dynamic properties are deprecated as of PHP 8.2.0, thus using them without marking the class with this attribute will emit a deprecation notice. ([from PHP](https://www.php.net/manual/en/migration82.deprecated.php#migration82.deprecated.core.dynamic-properties))

CakePhp does this very thing as a matter of principle and as such classes that extend `CakeObject` generally exhibit this behavior. 