### PR TITLE
fix: fixes use of 'self' in callables deprecated

### DIFF
--- a/lib/Cake/Utility/Hash.php
+++ b/lib/Cake/Utility/Hash.php
@@ -561,7 +561,7 @@ class Hash {
  * @return array Filtered array
  * @link https://book.cakephp.org/2.0/en/core-utility-libraries/hash.html#Hash::filter
  */
-	public static function filter(array $data, $callback = array('self', '_filter')) {
+	public static function filter(array $data, $callback = array(self::class, '_filter')) {
 		foreach ($data as $k => $v) {
 			if (is_array($v)) {
 				$data[$k] = static::filter($v, $callback);


### PR DESCRIPTION

fix: [fixes use of 'self' in callables deprecated](https://php.watch/versions/8.2/partially-supported-callable-deprecation)