### PR TITLE
fix: fixes method overrides should be compatible with parent

### DIFF
--- a/lib/Cake/Model/Validator/CakeValidationSet.php
+++ b/lib/Cake/Model/Validator/CakeValidationSet.php
@@ -310,7 +310,7 @@ class CakeValidationSet implements ArrayAccess, IteratorAggregate, Countable {
  * @param string $index name of the rule
  * @return bool
  */
-	public function offsetExists($index) {
+	public function offsetExists($index): bool {
 		return isset($this->_rules[$index]);
 	}
 
@@ -320,7 +320,7 @@ class CakeValidationSet implements ArrayAccess, IteratorAggregate, Countable {
  * @param string $index name of the rule
  * @return CakeValidationRule
  */
-	public function offsetGet($index) {
+	public function offsetGet($index): mixed {
 		return $this->_rules[$index];
 	}
 
@@ -335,7 +335,7 @@ class CakeValidationSet implements ArrayAccess, IteratorAggregate, Countable {
  * @return void
  * @see http://www.php.net/manual/en/arrayobject.offsetset.php
  */
-	public function offsetSet($index, $rule) {
+	public function offsetSet($index, $rule): void {
 		$this->setRule($index, $rule);
 	}
 
@@ -345,7 +345,7 @@ class CakeValidationSet implements ArrayAccess, IteratorAggregate, Countable {
  * @param string $index name of the rule
  * @return void
  */
-	public function offsetUnset($index) {
+	public function offsetUnset($index): void {
 		unset($this->_rules[$index]);
 	}
 
@@ -354,7 +354,7 @@ class CakeValidationSet implements ArrayAccess, IteratorAggregate, Countable {
  *
  * @return ArrayIterator
  */
-	public function getIterator() {
+	public function getIterator(): Traversable {
 		return new ArrayIterator($this->_rules);
 	}
 
@@ -363,7 +363,7 @@ class CakeValidationSet implements ArrayAccess, IteratorAggregate, Countable {
  *
  * @return int
  */
-	public function count() {
+	public function count(): int {
 		return count($this->_rules);
 	}
 


### PR DESCRIPTION
fix: fixes method [overrides should be compatible with parent](https://php.watch/versions/8.1/internal-method-return-types)

> It is likely that many PHP applications that extend/implement PHP internal classes/interfaces, but did not add return types, will encounter this deprecation notice. If the application can afford to drop PHP 5 and PHP 7.0 support, updating the child classes and implementations to add return types is the ideal fix. 